### PR TITLE
add proxy support 

### DIFF
--- a/http.go
+++ b/http.go
@@ -140,9 +140,9 @@ func ProxyAwareHttpClient(socks5_proxy string) *http.Client {
 	// set our socks5 as the dialer
 	if len(socks5_proxy) > 0 {
 		// create a socks5 dialer
-		dialer, err := proxy.SOCKS5("tcp", d.proxy, nil, proxy.Direct)
+		dialer, err := proxy.SOCKS5("tcp", socks5_proxy, nil, proxy.Direct)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "can't connect to the proxy:", err)
+			fmt.Fprintln(os.Stderr, "can't connect to the proxy: ", err)
 			return httpClient
 		}
 		httpTransport.Dial = dialer.Dial

--- a/main.go
+++ b/main.go
@@ -13,9 +13,11 @@ var displayProgress = true
 
 func main() {
 	var err error
+	var proxy string
 
-	conn    := flag.Int("n", runtime.NumCPU(), "connection")
+	conn := flag.Int("n", runtime.NumCPU(), "connection")
 	skiptls := flag.Bool("skip-tls", true, "skip verify certificate for https")
+	flag.StringVar(&proxy, "proxy", "", "socks5 proxy for downloading")
 
 	flag.Parse()
 	args := flag.Args()
@@ -47,7 +49,7 @@ func main() {
 
 		state, err := Resume(task)
 		FatalCheck(err)
-		Execute(state.Url, state, *conn, *skiptls)
+		Execute(state.Url, state, *conn, *skiptls, proxy)
 		return
 	} else {
 		if ExistDir(FolderOf(command)) {
@@ -55,11 +57,11 @@ func main() {
 			err := os.RemoveAll(FolderOf(command))
 			FatalCheck(err)
 		}
-		Execute(command, nil, *conn, *skiptls)
+		Execute(command, nil, *conn, *skiptls, proxy)
 	}
 }
 
-func Execute(url string, state *State, conn int, skiptls bool) {
+func Execute(url string, state *State, conn int, skiptls bool, proxy string) {
 	//otherwise is hget <URL> command
 	var err error
 
@@ -84,7 +86,7 @@ func Execute(url string, state *State, conn int, skiptls bool) {
 
 	var downloader *HttpDownloader
 	if state == nil {
-		downloader = NewHttpDownloader(url, conn, skiptls)
+		downloader = NewHttpDownloader(url, conn, skiptls, proxy)
 	} else {
 		downloader = &HttpDownloader{url: state.Url, file: filepath.Base(state.Url), par: int64(len(state.Parts)), parts: state.Parts, resumable: true}
 	}
@@ -132,7 +134,7 @@ func Execute(url string, state *State, conn int, skiptls bool) {
 
 func usage() {
 	Printf(`Usage:
-hget [URL] [-n connection] [-skip-tls true]
+hget [URL] [-n connection] [-skip-tls true] [-proxy socks5_proxy]
 hget tasks
 hget resume [TaskName]
 `)


### PR DESCRIPTION
we can have socks5 proxy support

usage:
```bash
hget -proxy "127.0.0.1:12345" https://releases.ubuntu.com/20.04.1/ubuntu-20.04.1-desktop-amd64.iso
```


we can also use the env and forget about the flag, something like this:
```go
proxyServer, isSet := os.LookupEnv("HTTP_PROXY")
if isSet {
	proxyUrl, err := url.Parse(proxyServer)
	if err == nil {
                dialer, err = proxy.FromURL(proxyUrl, proxy.Direct)
	}else if strings.HasPrefix("socks5://"){
                socksProxy := strings.Replace(proxyUrl, "socks5://", "", -1)
                dialer, err := proxy.SOCKS5("tcp", socksProxy, nil, proxy.Direct)
        }
}
```

let me know if you prefer the second method, so i can update the code accordingly 